### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/basketball-app-backup-20251028-075331/test-data/bbb/spielplan_list.jsp
+++ b/basketball-app-backup-20251028-075331/test-data/bbb/spielplan_list.jsp
@@ -37,7 +37,7 @@
 		var f = document.spielplanliste;
 		var ms_liga_id = f.cbMannschaftenFilter[f.cbMannschaftenFilter.selectedIndex].value;;
 		var spieltag = f.cbSpieltagFilter[f.cbSpieltagFilter.selectedIndex].value;
-		location.href='servlet/KalenderDienst?typ=2&liga_id=51961&ms_liga_id=' + ms_liga_id + '&spt=' + spieltag;
+		location.href = 'servlet/KalenderDienst?typ=2&liga_id=51961&ms_liga_id=' + encodeURIComponent(ms_liga_id) + '&spt=' + encodeURIComponent(spieltag);
 	}
 </script>
 


### PR DESCRIPTION
Potential fix for [https://github.com/OliEder/dbb-mini-bball-coach-app/security/code-scanning/5](https://github.com/OliEder/dbb-mini-bball-coach-app/security/code-scanning/5)

In general, the correct way to fix this is to ensure any untrusted data read from the DOM is properly encoded before being embedded in a URL or other sensitive context. For query parameters, JavaScript’s built-in `encodeURIComponent` function should be used to escape meta-characters so they cannot break out of their intended context.

Concretely, in `basketball-app-backup-20251028-075331/test-data/bbb/spielplan_list.jsp`, within the `showICalender()` JavaScript function, we should not concatenate `ms_liga_id` and `spieltag` directly into the URL. Instead, we should wrap both variables with `encodeURIComponent` in the `location.href` assignment. This preserves existing functionality (passing the same logical values to the servlet) while ensuring that any special characters are safely encoded in the query string. No additional imports are required; `encodeURIComponent` is a standard global function in browsers.

Specifically:
- Keep lines 37–39 as they are (reading from the form).
- Change line 40 from:
  - `location.href='servlet/KalenderDienst?typ=2&liga_id=51961&ms_liga_id=' + ms_liga_id + '&spt=' + spieltag;`
- To:
  - `location.href = 'servlet/KalenderDienst?typ=2&liga_id=51961&ms_liga_id=' + encodeURIComponent(ms_liga_id) + '&spt=' + encodeURIComponent(spieltag);`

This addresses both alert variants, since both tainted values are now encoded before being included in the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
