### PR TITLE
feat: team endpoint + onboarding redesign (DBv7 migration complete)

### DIFF
--- a/basketball-app/tsconfig.json
+++ b/basketball-app/tsconfig.json
@@ -22,7 +22,9 @@
 
     /* Paths */
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@shared/*": ["./src/shared/*"],
+      "@domains/*": ["./src/domains/*"]
     },
 
     /* Vite Types */


### PR DESCRIPTION
## Summary

- **BBBApiService:** `getTeamMatches(teamPermanentId)` — fetches all matches for a team via `/rest/team/id/{teamPermanentId}/matches` (single call, covers Liga + Pokal)
- **BBBSyncService:** `syncSpielplanForTeam(teamPermanentId, { fallbackLigaIds })` — uses team endpoint as primary, falls back to per-liga sync if unavailable
- **Onboarding (complete rebuild):** replaces Liga-URL flow with club search via static `clubs.json` from Vereinsregister GitHub Pages (client-side filtering, no proxy needed)
- **Tech debt cleanup:** removed duplicate `BBBSyncService.ts` from `shared/services/`, removed legacy `ClubDataService`/`LigaDiscoveryService`, removed duplicate `team.service.ts`
- **arc42 docs:** updated to v2.1 — context diagram, runtime views, tech debt table
- **tsconfig fix:** `@shared/*` and `@domains/*` path aliases added (was causing TS2307 in CI)

## Test Plan

- [ ] `npx vitest run` → 302 pass, 4 fail (expected: 1 Pact library bug TS-03, 3 BBBSyncService real-HTTP tests — pre-existing)
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] Manual: onboarding flow — search club by name, select team, verify `teamPermanentId` is stored
- [ ] Manual: BBB sync — trigger Liga sync, verify matches are fetched via team endpoint

## Known issues (not introduced by this PR)

- **TS-03:** `@pact-foundation/pact` v16 library bug (`messageConsumerPact` module missing) — upstream issue, not fixable here
- **TS-06:** Redundant `getTeamMatches` copy in `src/shared/services/BBBApiService.ts` — cosmetic, scheduled for follow-up cleanup

🤖 Generated with [OpenClaude](https://github.com/anthropics/claude-code)